### PR TITLE
Envio mas metadata, por ahora con el sha revision pero dejo lugar para completar los demas

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,23 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "86b123ab52087729368b884180798553",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.6",
+        "ext-sockets": "*",
+        "ext-openssl": "*",
+        "ext-json": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/src/TraceSession.php
+++ b/src/TraceSession.php
@@ -48,6 +48,44 @@ class TraceSession
                 'host' => $hostname,
             ],
         ];
+
+        self::$eventBuffer[] = [
+            'ApplicationEvent' => [
+                'timestamp' => Timestamp::formatNow(),
+                'event_value' => self::getMetadataPayload($app, $key, $apiVersion, $hostname),
+                'event_type' => 'scout.metadata',
+                'source' => 'php',
+            ],
+        ];
+    }
+
+    private static function getMetadataPayload($app, $key, $apiVersion, $hostname)
+    {
+        $payload = [
+            'language' => 'php',
+            // 'version' => PHP_VERSION, // Consider if this is needed
+            // 'language_version' => PHP_VERSION, // Consider if this is needed
+            // 'server_time' => Timestamp::formatNow(), // This will be the event timestamp
+            'framework' => '', // Lite version might not have this
+            'framework_version' => '', // Lite version might not have this
+            'environment' => '', // Lite version might not have this
+            'app_server' => '', // Lite version might not have this
+            'hostname' => $hostname,
+            'database_engine' => '', // Lite version might not have this
+            'database_adapter' => '', // Lite version might not have this
+            'application_name' => $app,
+            // 'libraries' => [], // Lite version might not have this
+            'paas' => '', // Lite version might not have this
+            'application_root' => '', // Lite version might not track this
+            'scm_subdirectory' => '', // Lite version might not track this
+        ];
+
+        $revisionSha = getenv('SCOUT_REVISION_SHA');
+        if ($revisionSha) {
+            $payload['git_sha'] = $revisionSha;
+        }
+
+        return $payload;
     }
 
     public static function startRequest()

--- a/src/TraceSession.php
+++ b/src/TraceSession.php
@@ -63,9 +63,9 @@ class TraceSession
     {
         $payload = [
             'language' => 'php',
-            // 'version' => PHP_VERSION, // Consider if this is needed
-            // 'language_version' => PHP_VERSION, // Consider if this is needed
-            // 'server_time' => Timestamp::formatNow(), // This will be the event timestamp
+            'version' => PHP_VERSION, // Consider if this is needed
+            'language_version' => PHP_VERSION, // Consider if this is needed
+            'server_time' => Timestamp::formatNow(), // This will be the event timestamp
             'framework' => '', // Lite version might not have this
             'framework_version' => '', // Lite version might not have this
             'environment' => '', // Lite version might not have this
@@ -74,7 +74,7 @@ class TraceSession
             'database_engine' => '', // Lite version might not have this
             'database_adapter' => '', // Lite version might not have this
             'application_name' => $app,
-            // 'libraries' => [], // Lite version might not have this
+            'libraries' => [], // Lite version might not have this
             'paas' => '', // Lite version might not have this
             'application_root' => '', // Lite version might not track this
             'scm_subdirectory' => '', // Lite version might not track this

--- a/tests/test.php
+++ b/tests/test.php
@@ -4,6 +4,80 @@ require_once 'vendor/autoload.php'; // if needed
 
 use AssetPlan\ScoutLiteAPM\TraceSession;
 
+echo "--- Running revision_sha tests ---\n";
+
+// Test Case 1: SCOUT_REVISION_SHA is set
+putenv('SCOUT_REVISION_SHA=test_revision_sha_123');
+TraceSession::resetSession(); // Reset session before test
+TraceSession::register('TestApp', 'TestKey', 'tcp://127.0.0.1:6590', '1.0', 'testhost');
+
+$reflectClass = new ReflectionClass(TraceSession::class);
+$eventBufferProp = $reflectClass->getProperty('eventBuffer');
+$eventBufferProp->setAccessible(true);
+$eventBuffer = $eventBufferProp->getValue();
+
+$testPassed = false;
+$applicationEvent = null;
+foreach ($eventBuffer as $eventWrapper) {
+    if (isset($eventWrapper['ApplicationEvent'])) {
+        $applicationEvent = $eventWrapper['ApplicationEvent'];
+        break;
+    }
+}
+
+if ($applicationEvent !== null) {
+    if ($applicationEvent['event_type'] === 'scout.metadata' &&
+        $applicationEvent['source'] === 'php' &&
+        is_array($applicationEvent['event_value']) &&
+        $applicationEvent['event_value']['application_name'] === 'TestApp' &&
+        !empty($applicationEvent['event_value']['hostname']) && // or specific value like 'testhost'
+        isset($applicationEvent['event_value']['git_sha']) &&
+        $applicationEvent['event_value']['git_sha'] === 'test_revision_sha_123') {
+        $testPassed = true;
+    }
+}
+
+if ($testPassed) {
+    echo "Test Case 1 (SCOUT_REVISION_SHA set): PASSED\n";
+} else {
+    echo "Test Case 1 (SCOUT_REVISION_SHA set): FAILED\n";
+    var_dump($eventBuffer); // Dump buffer on failure
+}
+
+// Test Case 2: SCOUT_REVISION_SHA is not set
+putenv('SCOUT_REVISION_SHA'); // Unset the environment variable
+TraceSession::resetSession(); // Reset session before test
+TraceSession::register('TestAppNoSha', 'TestKeyNoSha', 'tcp://127.0.0.1:6590', '1.0', 'testhostNoSha');
+$eventBuffer = $eventBufferProp->getValue();
+
+$testPassed = false;
+$applicationEvent = null;
+foreach ($eventBuffer as $eventWrapper) {
+    if (isset($eventWrapper['ApplicationEvent'])) {
+        $applicationEvent = $eventWrapper['ApplicationEvent'];
+        break;
+    }
+}
+
+if ($applicationEvent !== null) {
+    if (is_array($applicationEvent['event_value']) &&
+        !isset($applicationEvent['event_value']['git_sha']) &&
+        $applicationEvent['event_value']['application_name'] === 'TestAppNoSha' &&
+        $applicationEvent['event_value']['hostname'] === 'testhostNoSha') {
+        $testPassed = true;
+    }
+}
+
+if ($testPassed) {
+    echo "Test Case 2 (SCOUT_REVISION_SHA not set): PASSED\n";
+} else {
+    echo "Test Case 2 (SCOUT_REVISION_SHA not set): FAILED\n";
+    var_dump($eventBuffer); // Dump buffer on failure
+}
+
+echo "--- End of revision_sha tests ---\n\n";
+
+
 // Bootstrap with fake values
 TraceSession::bootstrap(getenv('SCOUT_APP_NAME'), getenv('SCOUT_KEY'), getenv('SCOUT_SOCKET_PATH'));
 


### PR DESCRIPTION
Jules lo implemento pero tuve que hacer el research con los repositorios para ver bien la estructura...

This commit refactors how metadata, including the revision SHA, is sent to Scout APM. It aligns more closely with the expected structure for metadata events.

Changes:
- Removed the previous `SetRevisionId` event.
- Introduced a new private static method `getMetadataPayload` in `TraceSession` to gather various metadata points such as `application_name`, `hostname`, `language`, and `git_sha` (from the `SCOUT_REVISION_SHA` environment variable).
- The `TraceSession::register` method now creates an `ApplicationEvent` with `event_type = 'scout.metadata'` and `source = 'php'`. The `event_value` of this event is populated by the `getMetadataPayload` method.
- Updated your tests in `tests/test.php` to verify the new `ApplicationEvent` structure and ensure `git_sha` is correctly included based on the `SCOUT_REVISION_SHA` environment variable. All tests pass.

This change provides a more standardized way of reporting application metadata to Scout.